### PR TITLE
Fix show and hide methods

### DIFF
--- a/src/css/winbox.css
+++ b/src/css/winbox.css
@@ -175,6 +175,10 @@
 .winbox.min .wb-body > * {
   display: none;
 }
+.winbox.hide {
+  display: none;
+  visibility: hidden;
+}
 .max {
   box-shadow: none;
 }

--- a/src/css/winbox.less
+++ b/src/css/winbox.less
@@ -203,6 +203,11 @@
   }
 }
 
+.winbox.hide {
+  display: none;
+  visibility: hidden;
+}
+
 &.max {
   box-shadow: none;
 }


### PR DESCRIPTION
As stated in #50 (the issue this fixes), the JavaScript adds and removes the `hide` class as expected but there was no CSS for that class to actually hide the window.