### PR TITLE
Make the header height and min-height for the window dependent on the CSS

### DIFF
--- a/src/css/winbox.css
+++ b/src/css/winbox.css
@@ -14,12 +14,25 @@
   /* workaround for using passive listeners */
   touch-action: none;
 }
+/* Header height */
+.winbox {
+  min-height: 35px;
+}
+.wb-header,
+.wb-icon {
+  height: 35px;
+}
+.wb-title {
+  line-height: 35px;
+}
+.wb-body {
+  top: 35px;
+}
 .wb-header {
   position: absolute;
   left: 0;
   top: 0;
   width: 100%;
-  height: 35px;
   color: #fff;
   overflow: hidden;
 }
@@ -27,7 +40,6 @@
   position: absolute;
   left: 0;
   right: 0;
-  top: 35px;
   bottom: 0;
   overflow: auto;
   -webkit-overflow-scrolling: touch;
@@ -44,8 +56,6 @@
   font-size: 14px;
   padding-left: 10px;
   cursor: move;
-  height: 35px;
-  line-height: 35px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -116,7 +126,6 @@
 }
 .wb-icon {
   float: right;
-  height: 35px;
   max-width: 100%;
   text-align: center;
 }

--- a/src/css/winbox.less
+++ b/src/css/winbox.less
@@ -17,12 +17,27 @@
   touch-action: none;
 }
 
+/* Header height */
+@winbox-header-height: 35px;
+.winbox {
+  min-height: @winbox-header-height;
+}
+.wb-header,
+.wb-icon {
+  height: @winbox-header-height;
+}
+.wb-title {
+  line-height: @winbox-header-height;
+}
+.wb-body {
+  top: @winbox-header-height;
+}
+
 .wb-header {
   position: absolute;
   left: 0;
   top: 0;
   width: 100%;
-  height: 35px;
   color: #fff;
   overflow: hidden;
 }
@@ -31,7 +46,6 @@
   position: absolute;
   left: 0;
   right: 0;
-  top: 35px;
   bottom: 0;
   overflow: auto;
   -webkit-overflow-scrolling: touch;
@@ -50,8 +64,6 @@
   font-size: 14px;
   padding-left: 10px;
   cursor: move;
-  height: 35px;
-  line-height: 35px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -131,7 +143,6 @@
 
 .wb-icon{
   float: right;
-  height: 35px;
   max-width: 100%;
   text-align: center;
 }

--- a/src/js/winbox.js
+++ b/src/js/winbox.js
@@ -369,14 +369,16 @@ function update_min_stack(){
         }
     }
 
-    for(let i = 0, self, key, width; i < len; i++){
+    for(let i = 0, self, key, width, header, headerHeight; i < len; i++){
 
         self = stack_min[i]
         key = self.left + ":" + self.top;
         width = Math.min((root_w - self.left - self.right) / tile_len[key], 250);
+        header = getByClass(self.dom, "wb-title");
+        headerHeight = header.clientHeight;
         tile_index[key] || (tile_index[key] = 0);
-        self.resize((width + 1) | 0, 35, true)
-            .move((self.left + tile_index[key] * width) | 0, root_h - self.bottom - 35, true);
+        self.resize((width + 1) | 0, 0, true)
+            .move((self.left + tile_index[key] * width) | 0, root_h - self.bottom - headerHeight, true);
         tile_index[key]++;
     }
 }
@@ -532,7 +534,7 @@ function addWindowListener(self, dir){
 
             if(resize_h){
 
-                self.height = Math.max(Math.min(self.height, root_h - self.y - self.bottom), 35);
+                self.height = Math.max(Math.min(self.height, root_h - self.y - self.bottom), 0);
             }
 
             use_raf ? raf_resize = true : self.resize();


### PR DESCRIPTION
This takes care of #52.

Instead of having the window be hard-coded to a min-height of 35px in the JavaScript, it's now entirely dependent on the CSS.

So you can now change the header height with the following CSS:

```css
.winbox {
  min-height: 20px;
}
.wb-header,
.wb-icon {
  height: 20px;
}
.wb-title {
  line-height: 20px;
}
.wb-body {
  top: 20px;
}
```

It would be nice if we could get this down to just one property that needs to be set, but that can be a project for another day.

I've also added a LESS variable to make setting this easy, so if you're compiling LESS you can just set the `@winbox-header-height` variable.