### PR TITLE
Add template option to allow for custom defined window templates

### DIFF
--- a/src/js/winbox.js
+++ b/src/js/winbox.js
@@ -40,11 +40,9 @@ function WinBox(params, _title){
 
     index || setup();
 
-    this.dom = template();
-    this.body = getByClass(this.dom, "wb-body");
-
     let id,
         root,
+        customTemplate,
         title,
         mount,
         html,
@@ -92,6 +90,7 @@ function WinBox(params, _title){
 
             id = params["id"];
             root = params["root"];
+            customTemplate = params["template"];
             title = title || params["title"];
             mount = params["mount"];
             html = params["html"];
@@ -117,17 +116,28 @@ function WinBox(params, _title){
             border = params["border"];
             classname = params["class"];
             splitscreen = params["splitscreen"];
-
-            if(background){
-
-                this.setBackground(background);
-            }
-
-            if(border){
-
-                setStyle(this.body, "margin", border + (isNaN(border) ? "" : "px"));
-            }
         }
+    }
+
+    if(customTemplate){
+
+        this.dom = customTemplate;
+    }
+    else{
+
+        this.dom = template();
+    }
+
+    this.body = getByClass(this.dom, "wb-body");
+
+    if(background){
+
+        this.setBackground(background);
+    }
+
+    if(border){
+
+        setStyle(this.body, "margin", border + (isNaN(border) ? "" : "px"));
     }
 
     this.setTitle(title || "");


### PR DESCRIPTION
This would take care of #43 and allow for defining custom window templates.

For example:

```js
var myWindowTemplate = document.createElement('div');

myWindowTemplate.innerHTML =  (
       '<div class=wb-header>' +
             '<div class=wb-min></div>' +
             '<div class=wb-title> </div>' +
             '<div class=wb-max></div>' +
             '<div class=wb-full></div>' +
             '<div class=wb-close></div>' +
        '</div>' +

        '<div class=wb-body></div>' +

        '<div class=wb-n></div>' +
        '<div class=wb-s></div>' +
        '<div class=wb-w></div>' +
        '<div class=wb-e></div>' +
        '<div class=wb-nw></div>' +
        '<div class=wb-ne></div>' +
        '<div class=wb-se></div>' +
        '<div class=wb-sw></div>'
);

new WinBox('My Custom Window', { template: myWindowTemplate });
```

Of course it would be up to the user to make their CSS work for their custom template but this would allow for a lot of flexibility and customization options.